### PR TITLE
Fixes mangastream repository for long chapters

### DIFF
--- a/MangaScrapeLib.Test/MangaScrapeLib.Test.csproj
+++ b/MangaScrapeLib.Test/MangaScrapeLib.Test.csproj
@@ -69,7 +69,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Repositories\MangaStreamRepositoryTest.cs" />
     <Compile Include="Repositories\MyMangaRepositoryTest.cs" />
-    <Compile Include="ClientTest.cs" />
     <Compile Include="Tools\UriToolsTest.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/MangaScrapeLib.Test/MangaScrapeLib.Test.csproj
+++ b/MangaScrapeLib.Test/MangaScrapeLib.Test.csproj
@@ -53,7 +53,9 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework">
+          <Private>False</Private>
+        </Reference>
       </ItemGroup>
     </Otherwise>
   </Choose>
@@ -67,6 +69,8 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Repositories\MangaStreamRepositoryTest.cs" />
     <Compile Include="Repositories\MyMangaRepositoryTest.cs" />
+    <Compile Include="ClientTest.cs" />
+    <Compile Include="Tools\UriToolsTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MangaScrapeLib\MangaScrapeLib.csproj">

--- a/MangaScrapeLib.Test/Tools/UriToolsTest.cs
+++ b/MangaScrapeLib.Test/Tools/UriToolsTest.cs
@@ -1,0 +1,23 @@
+﻿using MangaScrapeLib.Tools;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MangaScrapeLib.Test.Tools
+{
+    [TestClass]
+    public class UriToolsTest
+    {
+        [TestMethod]
+        public void TruncateLastUriSegmentRemovesLastSegment()
+        {
+            var testUri = "http://first.com/second/third";
+            Assert.AreEqual(UriTools.TruncateLastUriSegment(testUri), "http://first.com/second/");
+        }
+
+        [TestMethod]
+        public void GetLastUriSegmentGetsLastSegment()
+        {
+            var testUri = "http://first.com/second/third";
+            Assert.AreEqual(UriTools.GetLastUriSegment(testUri), "third");
+        }
+    }
+}

--- a/MangaScrapeLib/MangaScrapeLib.csproj
+++ b/MangaScrapeLib/MangaScrapeLib.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Repositories\NoFullListRepository.cs" />
     <Compile Include="Repositories\Repository.cs" />
     <Compile Include="Repositories\SeriesMetadataSupport.cs" />
+    <Compile Include="Tools\UriTools.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="MangaScrapeLib.nuspec" />

--- a/MangaScrapeLib/Repositories/MangaStreamRepository.cs
+++ b/MangaScrapeLib/Repositories/MangaStreamRepository.cs
@@ -62,8 +62,8 @@ namespace MangaScrapeLib.Repositories
             var linksNodes = listNode.QuerySelectorAll("a");
 
             /* 
-             * Mangastream doesnt't display all the pages in the Dropdown
-             * if the pages count exceed a certain amount.
+             * Mangastream doesn't display all the pages in the Dropdown
+             * if the pages count exceeds a certain amount.
              * Parsing the last item needs to be done to get the pages count accurately.
              */
             try

--- a/MangaScrapeLib/Repositories/MangaStreamRepository.cs
+++ b/MangaScrapeLib/Repositories/MangaStreamRepository.cs
@@ -1,6 +1,9 @@
 ﻿using MangaScrapeLib.Models;
+using MangaScrapeLib.Tools;
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 
 namespace MangaScrapeLib.Repositories
 {
@@ -55,9 +58,43 @@ namespace MangaScrapeLib.Repositories
         {
             var document = Parser.Parse(mangaPageHtml);
             var listNode = document.QuerySelectorAll("ul.dropdown-menu")[2];
+            
             var linksNodes = listNode.QuerySelectorAll("a");
-            var output = linksNodes.Select((d, e) => new Page(chapter, new Uri(d.Attributes["href"].Value), e + 1)).ToArray();
-            return output;
+
+            /* 
+             * Mangastream doesnt't display all the pages in the Dropdown
+             * if the pages count exceed a certain amount.
+             * Parsing the last item needs to be done to get the pages count accurately.
+             */
+            try
+            {
+                var lastLinkNode = linksNodes.Last();
+
+                var output = new List<Page>();
+
+                var uri = lastLinkNode.Attributes["href"].Value;
+                var lastPage = 0;
+
+                var couldParseLastPageNumber = int.TryParse(UriTools.GetLastUriSegment(uri), out lastPage);
+
+                if (!couldParseLastPageNumber)
+                {
+                    return new Page[0];
+                }
+
+                var baseUri = UriTools.TruncateLastUriSegment(uri);
+
+                for (var i = 1; i <= lastPage; i++)
+                {
+                    output.Add(new Page(chapter, new Uri(baseUri + i), i));
+                }
+
+                return output.ToArray();
+            }
+            catch (InvalidOperationException e)
+            {
+                return new Page[0];
+            }
         }
     }
 }

--- a/MangaScrapeLib/Tools/UriTools.cs
+++ b/MangaScrapeLib/Tools/UriTools.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Linq;
+
+namespace MangaScrapeLib.Tools
+{
+    /// <summary>
+    /// Utility class to manipulate Urls
+    /// </summary>
+    public static class UriTools
+    {
+        /// <summary>
+        /// Truncates the last URI segment.
+        /// </summary>
+        /// <param name="uri">The URI.</param>
+        /// <returns>The URI in string form without the last segment</returns>
+        public static string TruncateLastUriSegment(string uri)
+        {
+            var tempUri = new Uri(uri);
+            return tempUri.AbsoluteUri.Remove(tempUri.AbsoluteUri.Length - tempUri.Segments.Last().Length);
+        }
+
+        /// <summary>
+        /// Gets the last URI segment.
+        /// </summary>
+        /// <param name="uri">The URI.</param>
+        /// <returns>The last URI segment as a string</returns>
+        public static string GetLastUriSegment(string uri)
+        {
+            return uri.Split('/').Last();
+        }
+    }
+}


### PR DESCRIPTION
Mangastream doesn't display all the pages in the Dropdown of a Chapter if the pages count exceed a certain value (between 16 and 19, depends on the chapter).
In that case, the last item of the dropdown for the page selection contains the last page of the chapter.

For more reliable behavior, it's better to always parse the last item and extract the last page number from the URL and rebuild all the pages URLs from 1 to the last page. The BaseUrl of MangaStream for a specific chapter is always the same and only the last segment changes (it's the page number).