### PR TITLE
Changes the ImageUri build for MangaStream

### DIFF
--- a/MangaScrapeLib/Repositories/MangaStreamRepository.cs
+++ b/MangaScrapeLib/Repositories/MangaStreamRepository.cs
@@ -47,7 +47,7 @@ namespace MangaScrapeLib.Repositories
         {
             var document = Parser.Parse(mangaPageHtml);
             var imageNode = document.QuerySelector("img#manga-page");
-            var output = new Uri(imageNode.Attributes["src"].Value);
+            var output = new Uri($"http:{imageNode.Attributes["src"].Value}");
             return output;
         }
 


### PR DESCRIPTION
MangaStream changed the value in the src tag of their images by removing the http
protocol segment of the URL. Now it's like that `src="//link/to/the/picture.png"`

Specify the http protocol back during #the image url build otherwise it will create a local uri
using file://